### PR TITLE
[FIX] segmentation fault, when del hcontrol.Element

### DIFF
--- a/pyalsa/alsahcontrol.c
+++ b/pyalsa/alsahcontrol.c
@@ -621,7 +621,7 @@ static void
 pyalsahcontrolelement_dealloc(struct pyalsahcontrolelement *self)
 {
 	if (self->elem) {
-		Py_DECREF(self->callback);
+		Py_XDECREF(self->callback);
 		snd_hctl_elem_set_callback(self->elem, NULL);
 	}
 	Py_XDECREF(self->pyhandle);

--- a/test/hctltest1.py
+++ b/test/hctltest1.py
@@ -34,7 +34,10 @@ def value(element):
 		print('  %s: %s' % (a, getattr(value, a)))
 	values = value.get_tuple(info.type, info.count)
 	print('  Values:', values)
-	value.set_tuple(info.type, values)
+	try:
+		value.set_tuple(info.type, values)
+	except Exception as e:
+		print("EXCEPTION",e)
 	value.read()
 	if info.is_writable:
 		value.write()
@@ -61,9 +64,10 @@ list = hctl.list()
 print('List:')
 print(list)
 for l in list:
-	print('*****')
+	print('A*****')
 	element1 = alsahcontrol.Element(hctl, l[1:])
 	info(element1)
 	print('-----')
 	value(element1)
 del hctl
+print('TEST completed normally')


### PR DESCRIPTION
Segmentation Faults when deallocating a hcontrol.Element
the test  hcltest1.py was failing with segmentation fault when deallocating. The change in https://github.com/auphofBSF/alsa-python/blob/649e79740aa46242909087023cf3a1df701137fc/pyalsa/alsahcontrol.c#L624 to Py_XDECREF(self->callback) from Py_DECREF(self->callback) will mean it will not fail when a callback is not defined

tested on python 3.7 on Raspberry Pi 3 with Rasbian Lite (buster)