### PR TITLE
Fix seg. fault when accessing `ConstantObject` extra

### DIFF
--- a/pyalsa/alsaseq.c
+++ b/pyalsa/alsaseq.c
@@ -353,18 +353,11 @@ typedef struct {
 } ConstantObject;
 
 #if PY_MAJOR_VERSION < 3
-/* PyInt is fixed size in Python 2 */
 # define CONST_VALUE(x) PyInt_AsLong((PyObject *)x)
-# define CONST_EXTRA(x) (&(x->extra))
 #else
-/* PyLong is variable size in Python 3 */
 # define CONST_VALUE(x) PyLong_AsLong((PyObject *)x)
-# define CONST_EXTRA(x) \
-    ((ConstantExtraFields *)( \
-        ((intptr_t)(&x->extra)) \
-        + abs(Py_SIZE(&x->base)) * Py_TYPE(x)->tp_itemsize \
-    ))
 #endif
+# define CONST_EXTRA(x) (&(x->extra))
 
 /** alsaseq.Constant type (initialized later...) */
 static PyTypeObject ConstantType;


### PR DESCRIPTION
This fixes (#9) a segmentation fault that started happening with python 3.12, changes in the PyLongObject implementation have broken some pointer arithmetic, which, from what I understand, is not necessary.

Probably someone with a better understanding of C should check this :)

I've tested with 3.12, 3.11 and 3.7.