### PR TITLE
Use PyBytes and not Unicode strings for IEC958 values

### DIFF
--- a/pyalsa/alsahcontrol.c
+++ b/pyalsa/alsahcontrol.c
@@ -1052,13 +1052,13 @@ pyalsahcontrolvalue_get1(struct pyalsahcontrolvalue *self, PyObject *args, int l
 		}
 		snd_ctl_elem_value_get_iec958(self->value, iec958);
 		if (!list) {
-			PyTuple_SET_ITEM(t, 0, PyUnicode_FromStringAndSize((char *)iec958->status, sizeof(iec958->status)));
-			PyTuple_SET_ITEM(t, 1, PyUnicode_FromStringAndSize((char *)iec958->subcode, sizeof(iec958->subcode)));
-			PyTuple_SET_ITEM(t, 2, PyUnicode_FromStringAndSize((char *)iec958->dig_subframe, sizeof(iec958->dig_subframe)));
+			PyTuple_SET_ITEM(t, 0, PyBytes_FromStringAndSize((char *)iec958->status, sizeof(iec958->status)));
+			PyTuple_SET_ITEM(t, 1, PyBytes_FromStringAndSize((char *)iec958->subcode, sizeof(iec958->subcode)));
+			PyTuple_SET_ITEM(t, 2, PyBytes_FromStringAndSize((char *)iec958->dig_subframe, sizeof(iec958->dig_subframe)));
 		} else {
-			PyList_SetItem(t, 0, PyUnicode_FromStringAndSize((char *)iec958->status, sizeof(iec958->status)));
-			PyList_SetItem(t, 1, PyUnicode_FromStringAndSize((char *)iec958->subcode, sizeof(iec958->subcode)));
-			PyList_SetItem(t, 2, PyUnicode_FromStringAndSize((char *)iec958->dig_subframe, sizeof(iec958->dig_subframe)));
+			PyList_SetItem(t, 0, PyBytes_FromStringAndSize((char *)iec958->status, sizeof(iec958->status)));
+			PyList_SetItem(t, 1, PyBytes_FromStringAndSize((char *)iec958->subcode, sizeof(iec958->subcode)));
+			PyList_SetItem(t, 2, PyBytes_FromStringAndSize((char *)iec958->dig_subframe, sizeof(iec958->dig_subframe)));
 		}
 		free(iec958);
 		break;
@@ -1176,30 +1176,33 @@ pyalsahcontrolvalue_settuple(struct pyalsahcontrolvalue *self, PyObject *args)
 			Py_DECREF(t);
 			Py_RETURN_NONE;
 		}
-		len = 0;
 		v = !list ? PyTuple_GET_ITEM(t, 0) : PyList_GetItem(t, 0);
 		Py_INCREF(v);
-		if (PyBytes_AsStringAndSize(v, &str, &len))
+		if (!PyBytes_Check(v))
 			goto err1;
+		len = PyBytes_Size(v);
 		if (len > (Py_ssize_t)sizeof(iec958->status))
-			len = sizeof(iec958->status);
-		memcpy(iec958->status, str, len);
-		len = 0;
+			len = (Py_ssize_t)sizeof(iec958->status);
+		str = PyBytes_AsString(v);
+		memcpy(iec958->status, str, (size_t)len);
 		v = !list ? PyTuple_GET_ITEM(t, 1) : PyList_GetItem(t, 1);
 		Py_INCREF(v);
-		if (PyBytes_AsStringAndSize(v, &str, &len))
+		if (!PyBytes_Check(v))
 			goto err1;
+		len = PyBytes_Size(v);
 		if (len > (Py_ssize_t)sizeof(iec958->subcode))
-			len = sizeof(iec958->subcode);
-		memcpy(iec958->subcode, str, len);
-		len = 0;
+			len = (Py_ssize_t)sizeof(iec958->subcode);
+		str = PyBytes_AsString(v);
+		memcpy(iec958->subcode, str, (size_t)len);
 		v = !list ? PyTuple_GET_ITEM(t, 2) : PyList_GetItem(t, 2);
 		Py_INCREF(v);
-		if (PyBytes_AsStringAndSize(v, &str, &len))
+		if (!PyBytes_Check(v))
 			goto err1;
+		len = PyBytes_Size(v);
 		if (len > (Py_ssize_t)sizeof(iec958->dig_subframe))
-			len = sizeof(iec958->dig_subframe);
-		memcpy(iec958->dig_subframe, str, len);
+			len = (Py_ssize_t)sizeof(iec958->dig_subframe);
+		str = PyBytes_AsString(v);
+		memcpy(iec958->dig_subframe, str, (size_t)len);
 		free(iec958);
 		break;
 	      err1:

--- a/pyalsa/alsahcontrol.c
+++ b/pyalsa/alsahcontrol.c
@@ -1203,6 +1203,7 @@ pyalsahcontrolvalue_settuple(struct pyalsahcontrolvalue *self, PyObject *args)
 			len = (Py_ssize_t)sizeof(iec958->dig_subframe);
 		str = PyBytes_AsString(v);
 		memcpy(iec958->dig_subframe, str, (size_t)len);
+		snd_ctl_elem_value_set_iec958(self->value, iec958);
 		free(iec958);
 		break;
 	      err1:

--- a/test/hctltest1.py
+++ b/test/hctltest1.py
@@ -32,6 +32,8 @@ def value(element):
 		if a.startswith('__'):
 			continue
 		print('  %s: %s' % (a, getattr(value, a)))
+	if info.count == 0:
+		return
 	values = value.get_tuple(info.type, info.count)
 	print('  Values:', values)
 	value.set_tuple(info.type, values)


### PR DESCRIPTION
Suggested fix for #13.

- the first commit is not strictly related but also needed to avoid hctltest1.py crashing with my audio devices, where some have info.count = 0. Let me know if more information is needed. I don't know if this is expected or if a warning should be issued.

- I went for PyBytes instead of PyByteArray
 
- for setting values, if the provided PyBytes value is shorter than the value, it will be zero-padded.
  - if it is too long, it will be silently truncated
 
- following the existing code style, no empty lines were inserted, but this could help readability

- the third commit is not for fixing the crash, but for fixing set_tuple() to actually do anything for IEC958

- I haven't changed the reference counting, which seems wrong to me in the original code as well. This would be a different issue.