### PR TITLE
alsaseq: Fix type check in set_time()

### DIFF
--- a/pyalsa/alsaseq.c
+++ b/pyalsa/alsaseq.c
@@ -847,7 +847,7 @@ SeqEvent_set_time(SeqEventObject *self,
 		  PyObject *val) {
   long lval = 0;
   const int is_float = PyFloat_Check(val);
-  const int is_int = is_float ? 0 : get_long1(val, &lval);
+  const int is_int = is_float ? 0 : !get_long1(val, &lval);
 
   if (!(is_int || is_float)) {
     PyErr_Format(PyExc_TypeError,


### PR DESCRIPTION
SeqEvent_set_time() has fallen victim to the inverted get_long1() return value here, erroring out when called with actual integers.